### PR TITLE
Make output groups.tsv optional for array inputs

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,10 +1,10 @@
 {
-  "name": "eggd_somalier_relate_v1.0.1",
-  "title": "eggd_somalier_relate_v1.0.1",
-  "summary": "CChecks relatedness and sex of sample",
-  "dxapi": "1.0.1", 
+  "name": "eggd_somalier_relate_v1.0.2",
+  "title": "eggd_somalier_relate_v1.0.2",
+  "summary": "Checks relatedness and sex of sample",
+  "dxapi": "1.0.2", 
   "properties": {
-    "githubRelease": "v1.0.1"
+    "githubRelease": "v1.0.2"
   },
   "inputSpec": [
     {
@@ -58,7 +58,8 @@
       "patterns": [
         "*"
       ],
-      "help": "Grouping samples together based on relatedness"
+      "help": "Grouping samples together based on relatedness",
+      "optional": true
     },
     {
       "name": "ped_output",

--- a/src/eggd_somalier_relate.sh
+++ b/src/eggd_somalier_relate.sh
@@ -44,14 +44,21 @@ main() {
     mkdir -p /home/dnanexus/out/html/
     mkdir -p /home/dnanexus/out/pairs_tsv/
     mkdir -p /home/dnanexus/out/samples_tsv/
-    mkdir -p /home/dnanexus/out/groups_tsv/
     mkdir -p /home/dnanexus/out/ped_output
 
     mv *somalier.html /home/dnanexus/out/html/
     mv *somalier.pairs.tsv /home/dnanexus/out/pairs_tsv/
     mv *somalier.samples.tsv /home/dnanexus/out/samples_tsv/
-    mv *somalier.groups.tsv /home/dnanexus/out/groups_tsv/
     mv Samples.ped /home/dnanexus/out/ped_output
+    
+    # If a single somalier file is inputted, groups.tsv file is not generated
+    if [ -f *somalier.groups.tsv ]; then
+        echo "somalier.groups.tsv exists."
+        mkdir -p /home/dnanexus/out/groups_tsv/
+        mv *somalier.groups.tsv /home/dnanexus/out/groups_tsv/
+    else
+        echo "somalier.groups.tsv does not exist as a single sample was used"
+    fi
 
     dx-upload-all-outputs
 


### PR DESCRIPTION
Issue with handling single samples inputs as groups.tsv file is a required output but is only generated in array inputs.

Made output for groups.tsv optional in json and only create output directory if file exists

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_somalier_relate/4)
<!-- Reviewable:end -->
